### PR TITLE
Make pretrained models compitable with CPU-only instances

### DIFF
--- a/torchsr/models/carn.py
+++ b/torchsr/models/carn.py
@@ -265,7 +265,7 @@ class CARNMBlock(nn.Module):
         
 
 class CARNM(nn.Module):
-    def __init__(self, scale, pretrained):
+    def __init__(self, scale, pretrained, map_location=None):
         super(CARNM, self).__init__()
         
         multi_scale = True
@@ -290,7 +290,7 @@ class CARNM(nn.Module):
         self.exit = nn.Conv2d(64, 3, 3, 1, 1)
 
         if pretrained:
-            self.load_pretrained()
+            self.load_pretrained(map_location=map_location)
                 
     def forward(self, x, scale=None):
         if self.scale is not None:
@@ -324,9 +324,11 @@ class CARNM(nn.Module):
 
         return out
 
-    def load_pretrained(self):
+    def load_pretrained(self, map_location=None):
         state_dict = load_state_dict_from_url(urls["carn_m"], progress=True)
-        self.load_state_dict(state_dict)
+        if not torch.cuda.is_available():
+            map_location = torch.device('cpu')
+        self.load_state_dict(state_dict, map_location=map_location)
 
 
 def carn(scale, pretrained=False):

--- a/torchsr/models/carn.py
+++ b/torchsr/models/carn.py
@@ -172,7 +172,7 @@ class CARNBlock(nn.Module):
         
 
 class CARN(nn.Module):
-    def __init__(self, scale, pretrained):
+    def __init__(self, scale, pretrained=False, map_location=None):
         super(CARN, self).__init__()
         
         multi_scale = True
@@ -197,7 +197,7 @@ class CARN(nn.Module):
         self.exit = nn.Conv2d(64, 3, 3, 1, 1)
 
         if pretrained:
-            self.load_pretrained()
+            self.load_pretrained(map_location=map_location)
                 
     def forward(self, x, scale=None):
         if self.scale is not None:
@@ -230,8 +230,10 @@ class CARN(nn.Module):
 
         return out
 
-    def load_pretrained(self):
-        state_dict = load_state_dict_from_url(urls["carn"], progress=True)
+    def load_pretrained(self, map_location=None):
+        if not torch.cuda.is_available():
+            map_location = torch.device('cpu')
+        state_dict = load_state_dict_from_url(urls["carn"], map_location=map_location, progress=True)
         self.load_state_dict(state_dict)
 
 
@@ -265,7 +267,7 @@ class CARNMBlock(nn.Module):
         
 
 class CARNM(nn.Module):
-    def __init__(self, scale, pretrained, map_location=None):
+    def __init__(self, scale, pretrained=False, map_location=None):
         super(CARNM, self).__init__()
         
         multi_scale = True
@@ -325,10 +327,10 @@ class CARNM(nn.Module):
         return out
 
     def load_pretrained(self, map_location=None):
-        state_dict = load_state_dict_from_url(urls["carn_m"], progress=True)
         if not torch.cuda.is_available():
             map_location = torch.device('cpu')
-        self.load_state_dict(state_dict, map_location=map_location)
+        state_dict = load_state_dict_from_url(urls["carn_m"], map_location=map_location, progress=True)
+        self.load_state_dict(state_dict)
 
 
 def carn(scale, pretrained=False):

--- a/torchsr/models/edsr.py
+++ b/torchsr/models/edsr.py
@@ -93,7 +93,7 @@ class Upsampler(nn.Sequential):
 
 
 class EDSR(nn.Module):
-    def __init__(self, n_resblocks, n_feats, scale, res_scale, pretrained=False):
+    def __init__(self, n_resblocks, n_feats, scale, res_scale, pretrained=False, map_location=None):
         super(EDSR, self).__init__()
         self.scale = scale
 
@@ -132,7 +132,7 @@ class EDSR(nn.Module):
         self.tail = nn.Sequential(*m_tail)
 
         if pretrained:
-            self.load_pretrained()
+            self.load_pretrained(map_location=map_location)
 
     def forward(self, x, scale=None):
         if scale is not None and scale != self.scale:
@@ -148,10 +148,12 @@ class EDSR(nn.Module):
 
         return x 
 
-    def load_pretrained(self):
+    def load_pretrained(self, map_location=None):
         if self.url is None:
             raise KeyError("No URL available for this model")
-        state_dict = load_state_dict_from_url(self.url, progress=True)
+        if not torch.cuda.is_available():
+            map_location = torch.device('cpu')
+        state_dict = load_state_dict_from_url(self.url, map_location=map_location, progress=True)
         self.load_state_dict(state_dict)
 
 

--- a/torchsr/models/ninasr.py
+++ b/torchsr/models/ninasr.py
@@ -82,7 +82,7 @@ class Rescale(nn.Module):
 
 
 class NinaSR(nn.Module):
-    def __init__(self, n_resblocks, n_feats, scale, pretrained=False, expansion=2.0):
+    def __init__(self, n_resblocks, n_feats, scale, pretrained=False, map_location=None, expansion=2.0):
         super(NinaSR, self).__init__()
         self.scale = scale
 
@@ -98,7 +98,7 @@ class NinaSR(nn.Module):
         self.tail = NinaSR.make_tail(n_colors, n_feats, scale)
 
         if pretrained:
-            self.load_pretrained()
+            self.load_pretrained(map_location=map_location)
 
     @staticmethod
     def make_head(n_colors, n_feats):
@@ -138,10 +138,12 @@ class NinaSR(nn.Module):
         x = self.tail(res)
         return x
 
-    def load_pretrained(self):
+    def load_pretrained(self, map_location=None):
         if self.url is None:
             raise KeyError("No URL available for this model")
-        state_dict = load_state_dict_from_url(self.url, progress=True)
+        if not torch.cuda.is_available():
+            map_location = torch.device('cpu')
+        state_dict = load_state_dict_from_url(self.url, map_location=map_location, progress=True)
         self.load_state_dict(state_dict)
 
 

--- a/torchsr/models/rcan.py
+++ b/torchsr/models/rcan.py
@@ -127,7 +127,7 @@ class ResidualGroup(nn.Module):
 
 ## Residual Channel Attention Network (RCAN)
 class RCAN(nn.Module):
-    def __init__(self, n_resgroups, n_resblocks, n_feats, reduction, scale, pretrained=False):
+    def __init__(self, n_resgroups, n_resblocks, n_feats, reduction, scale, pretrained=False, map_location=None):
         super(RCAN, self).__init__()
         self.scale = scale
         
@@ -168,7 +168,7 @@ class RCAN(nn.Module):
         self.tail = nn.Sequential(*modules_tail)
 
         if pretrained:
-            self.load_pretrained()
+            self.load_pretrained(map_location=map_location)
 
     def forward(self, x, scale=None):
         if scale is not None and scale != self.scale:
@@ -184,10 +184,12 @@ class RCAN(nn.Module):
 
         return x 
 
-    def load_pretrained(self):
+    def load_pretrained(self, map_location=None):
         if self.url is None:
             raise KeyError("No URL available for this model")
-        state_dict = load_state_dict_from_url(self.url, progress=True)
+        if not torch.cuda.is_available():
+            map_location = torch.device('cpu')
+        state_dict = load_state_dict_from_url(self.url, map_location=map_location, progress=True)
         self.load_state_dict(state_dict)
 
 

--- a/torchsr/models/rdn.py
+++ b/torchsr/models/rdn.py
@@ -48,7 +48,7 @@ class RDB(nn.Module):
 
 
 class RDN(nn.Module):
-    def __init__(self, scale, G0, D, C, G, pretrained=False):
+    def __init__(self, scale, G0, D, C, G, pretrained=False, map_location=None):
         super(RDN, self).__init__()
         self.scale = scale
 
@@ -98,7 +98,7 @@ class RDN(nn.Module):
         self.output = nn.Conv2d(G, n_colors, kSize, padding=(kSize-1)//2, stride=1)
 
         if pretrained:
-            self.load_pretrained()
+            self.load_pretrained(map_location=map_location)
 
     def forward(self, x, scale=None):
         if scale is not None and scale != self.scale:
@@ -116,10 +116,12 @@ class RDN(nn.Module):
 
         return self.output(self.upscale(x))
 
-    def load_pretrained(self):
+    def load_pretrained(self, map_location=None):
         if self.url is None:
             raise KeyError("No URL available for this model")
-        state_dict = load_state_dict_from_url(self.url, progress=True)
+        if not torch.cuda.is_available():
+            map_location = torch.device('cpu')
+        state_dict = load_state_dict_from_url(self.url, map_location=map_location, progress=True)
         self.load_state_dict(state_dict)
 
 

--- a/torchsr/models/vdsr.py
+++ b/torchsr/models/vdsr.py
@@ -4,6 +4,7 @@
 
 import torch
 import torch.nn as nn
+from torchvision.models.utils import load_state_dict_from_url
 
 __all__ = [ 'vdsr', 'vdsr_r20f64', ]
 
@@ -30,7 +31,7 @@ class MeanShift(nn.Conv2d):
 
 
 class VDSR(nn.Module):
-    def __init__(self, n_resblocks, n_feats, scale, pretrained):
+    def __init__(self, n_resblocks, n_feats, scale, pretrained, map_location=None):
         super(VDSR, self).__init__()
         self.scale = scale
 
@@ -59,7 +60,7 @@ class VDSR(nn.Module):
         self.body = nn.Sequential(*m_body)
 
         if pretrained:
-            self.load_pretrained()
+            self.load_pretrained(map_location=map_location)
 
     def forward(self, x, scale=None):
         if scale is not None and scale != self.scale:
@@ -71,10 +72,12 @@ class VDSR(nn.Module):
         x = self.add_mean(res)
         return x 
 
-    def load_pretrained(self):
+    def load_pretrained(self, map_location=None):
         if self.url is None:
             raise KeyError("No URL available for this model")
-        state_dict = load_state_dict_from_url(self.url, progress=True)
+        if not torch.cuda.is_available():
+            map_location = torch.device('cpu')
+        state_dict = load_state_dict_from_url(self.url, map_location=map_location, progress=True)
         self.load_state_dict(state_dict)
 
 


### PR DESCRIPTION
Set `pretrained=True` in a CPU-only environment will cause an exception:
```
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.
```
